### PR TITLE
feat: add player and stats models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Thumbs.db
 # Project specific
 migrations/versions/*
 !migrations/versions/.gitkeep
+instance/

--- a/src/extensions.py
+++ b/src/extensions.py
@@ -1,0 +1,6 @@
+"""Application extensions used across the service."""
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+"""Database extension instance."""

--- a/src/main.py
+++ b/src/main.py
@@ -1,36 +1,56 @@
-"""
-umbra-player-service - Service de gestion des profils et données des joueurs
-"""
+"""umbra-player-service - Service de gestion des profils et données des joueurs."""
+
 import os
+
 from flask import Flask, jsonify
 from flask_cors import CORS
 
+from .extensions import db
+from .models import Player, PlayerStats
+
 
 def create_app() -> Flask:
+    """Create and configure the Flask application."""
+
     app = Flask(__name__)
     CORS(app)
-    
+
     # Configuration
-    app.config['DEBUG'] = os.getenv('FLASK_DEBUG', '0') == '1'
-    
+    app.config.setdefault(
+        "SQLALCHEMY_DATABASE_URI", os.getenv("DATABASE_URL", "sqlite:///players.db")
+    )
+    app.config.setdefault("SQLALCHEMY_TRACK_MODIFICATIONS", False)
+    app.config["DEBUG"] = os.getenv("FLASK_DEBUG", "0") == "1"
+
+    db.init_app(app)
+
     # Health check endpoint
-    @app.route('/health')
+    @app.route("/health")
     def health():
-        return jsonify({
-            'success': True,
-            'data': {
-                'status': 'healthy',
-                'service': 'umbra-player-service'
-            },
-            'message': 'Service en bonne santé'
-        }), 200
-    
+        return (
+            jsonify(
+                {
+                    "success": True,
+                    "data": {
+                        "status": "healthy",
+                        "service": "umbra-player-service",
+                    },
+                    "message": "Service en bonne santé",
+                }
+            ),
+            200,
+        )
+
+    @app.shell_context_processor
+    def shell_context():  # pragma: no cover - dev convenience
+        return {"db": db, "Player": Player, "PlayerStats": PlayerStats}
+
     # TODO: Ajouter les routes spécifiques au service
-    
+
     return app
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app = create_app()
-    port = int(os.getenv('PORT', '5001'))
-    app.run(host='0.0.0.0', port=port, debug=True)
+    port = int(os.getenv("PORT", "5001"))
+    app.run(host="0.0.0.0", port=port, debug=True)

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,104 @@
+"""Database models for player profiles and statistics."""
+
+from sqlalchemy import CheckConstraint
+
+from .extensions import db
+
+
+class Player(db.Model):
+    """Represents a player profile within the Umbra universe."""
+
+    __tablename__ = "players"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.String(64), nullable=False, unique=True)
+    name = db.Column(db.String(120), nullable=False)
+    level = db.Column(db.Integer, nullable=False, default=1)
+    xp = db.Column(db.Integer, nullable=False, default=0)
+
+    stats = db.relationship(
+        "PlayerStats",
+        back_populates="player",
+        uselist=False,
+        cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (
+        CheckConstraint("level >= 1", name="ck_player_level_positive"),
+        CheckConstraint("xp >= 0", name="ck_player_xp_non_negative"),
+    )
+
+    def xp_to_next_level(self) -> int:
+        """Return the amount of experience required to reach the next level."""
+
+        return max(self.level, 1) * 100
+
+    def add_experience(self, amount: int) -> int:
+        """Add experience points and perform level ups when necessary.
+
+        Args:
+            amount: Experience points to add.
+
+        Returns:
+            The number of levels gained after applying the experience.
+
+        Raises:
+            ValueError: If *amount* is negative.
+        """
+
+        if amount < 0:
+            raise ValueError("Experience amount must be non-negative.")
+
+        self.xp += amount
+        levels_gained = 0
+
+        while self.xp >= self.xp_to_next_level():
+            required_xp = self.xp_to_next_level()
+            self.xp -= required_xp
+            self.level += 1
+            levels_gained += 1
+
+        return levels_gained
+
+    def progress_to_next_level(self) -> float:
+        """Return the normalized progress towards the next level."""
+
+        required_xp = self.xp_to_next_level()
+        if required_xp == 0:
+            return 0.0
+
+        return min(self.xp / required_xp, 1.0)
+
+    def __repr__(self) -> str:  # pragma: no cover - convenience method
+        return f"<Player id={self.id!r} name={self.name!r} level={self.level!r}>"
+
+
+class PlayerStats(db.Model):
+    """Represents the combat statistics for a player."""
+
+    __tablename__ = "player_stats"
+
+    id = db.Column(db.Integer, primary_key=True)
+    player_id = db.Column(
+        db.Integer, db.ForeignKey("players.id"), nullable=False, unique=True
+    )
+    health = db.Column(db.Integer, nullable=False, default=100)
+    attack = db.Column(db.Integer, nullable=False, default=10)
+    defense = db.Column(db.Integer, nullable=False, default=5)
+
+    player = db.relationship("Player", back_populates="stats")
+
+    __table_args__ = (
+        CheckConstraint("health >= 0", name="ck_player_stats_health_non_negative"),
+        CheckConstraint("attack >= 0", name="ck_player_stats_attack_non_negative"),
+        CheckConstraint("defense >= 0", name="ck_player_stats_defense_non_negative"),
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - convenience method
+        return (
+            "<PlayerStats "
+            f"player_id={self.player_id!r} "
+            f"health={self.health!r} "
+            f"attack={self.attack!r} "
+            f"defense={self.defense!r}>"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,29 @@
 import pytest
+
+from src.extensions import db
 from src.main import create_app
 
 
 @pytest.fixture
 def app():
     """Create application for testing."""
+
     app = create_app()
-    app.config['TESTING'] = True
-    return app
+    app.config.update(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": "sqlite://",
+        }
+    )
+
+    with app.app_context():
+        db.create_all()
+
+    yield app
+
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
 
 
 @pytest.fixture

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -3,12 +3,12 @@
 
 def test_health_endpoint(client):
     """Test de l'endpoint /health."""
-    response = client.get('/health')
-    
+    response = client.get("/health")
+
     assert response.status_code == 200
-    
+
     data = response.get_json()
-    assert data['success'] is True
-    assert data['data']['status'] == 'healthy'
-    assert data['data']['service'] == 'umbra-player-service'
-    assert 'Service en bonne santé' in data['message']
+    assert data["success"] is True
+    assert data["data"]["status"] == "healthy"
+    assert data["data"]["service"] == "umbra-player-service"
+    assert "Service en bonne santé" in data["message"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,49 @@
+"""Tests for the player and player stats models."""
+import pytest
+
+from src.extensions import db
+from src.models import Player, PlayerStats
+
+
+def test_player_stats_relationship(app):
+    """A player should expose a one-to-one relationship with stats."""
+
+    with app.app_context():
+        player = Player(
+            user_id="user-001",
+            name="Umbra",
+            stats=PlayerStats(health=120, attack=15, defense=9),
+        )
+        db.session.add(player)
+        db.session.commit()
+
+        retrieved = Player.query.filter_by(user_id="user-001").one()
+
+        assert retrieved.stats is not None
+        assert retrieved.stats.health == 120
+        assert retrieved.stats.player is retrieved
+
+
+def test_player_add_experience_levels_up(app):
+    """Experience should accumulate and trigger level ups when thresholds are met."""
+
+    with app.app_context():
+        player = Player(user_id="user-002", name="Adept")
+        db.session.add(player)
+        db.session.commit()
+
+        levels_gained = player.add_experience(350)
+
+        assert levels_gained == 2
+        assert player.level == 3
+        assert player.xp == 50  # 350 - (100 + 200)
+
+
+def test_player_add_experience_rejects_negative_amount(app):
+    """Negative experience amounts are not allowed."""
+
+    with app.app_context():
+        player = Player(user_id="user-003", name="Rogue")
+
+        with pytest.raises(ValueError):
+            player.add_experience(-5)


### PR DESCRIPTION
## Summary
- configure the Flask app with SQLAlchemy and expose the database models in the shell context
- implement Player and PlayerStats ORM models with experience handling helpers
- extend the test suite with database fixtures and model behavior coverage

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d1a43b12b48332aed6e90e53ab24a3