### PR TITLE
feat: add player retrieval endpoint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,11 @@
 """umbra-player-service - Service de gestion des profils et données des joueurs."""
 
 import os
+from typing import Any, Dict, Optional
 
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from flask_cors import CORS
+from sqlalchemy.orm import joinedload
 
 from .extensions import db
 from .models import Player, PlayerStats
@@ -23,6 +25,61 @@ def create_app() -> Flask:
     app.config["DEBUG"] = os.getenv("FLASK_DEBUG", "0") == "1"
 
     db.init_app(app)
+
+    app.config.setdefault("API_AUTH_TOKEN", os.getenv("API_AUTH_TOKEN"))
+
+    def _build_success_response(data: Dict[str, Any], message: str, status: int = 200):
+        return (
+            jsonify(
+                {
+                    "success": True,
+                    "data": data,
+                    "message": message,
+                    "error": None,
+                    "meta": None,
+                }
+            ),
+            status,
+        )
+
+    def _build_error_response(
+        message: str, error_code: str, status: int, error_message: Optional[str] = None
+    ):
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "data": None,
+                    "message": message,
+                    "error": {
+                        "code": error_code,
+                        "message": error_message or message,
+                    },
+                    "meta": None,
+                }
+            ),
+            status,
+        )
+
+    def _serialize_stats(stats: Optional[PlayerStats]) -> Optional[Dict[str, Any]]:
+        if stats is None:
+            return None
+
+        return {
+            "health": stats.health,
+            "attack": stats.attack,
+            "defense": stats.defense,
+        }
+
+    def _serialize_player(player: Player) -> Dict[str, Any]:
+        return {
+            "id": player.id,
+            "user_id": player.user_id,
+            "name": player.name,
+            "level": player.level,
+            "xp": player.xp,
+            "stats": _serialize_stats(player.stats),
+        }
 
     # Health check endpoint
     @app.route("/health")
@@ -45,7 +102,40 @@ def create_app() -> Flask:
     def shell_context():  # pragma: no cover - dev convenience
         return {"db": db, "Player": Player, "PlayerStats": PlayerStats}
 
-    # TODO: Ajouter les routes spécifiques au service
+    @app.route("/players/<int:player_id>", methods=["GET"])
+    def get_player(player_id: int):
+        expected_token = app.config.get("API_AUTH_TOKEN")
+
+        auth_header = request.headers.get("Authorization", "")
+        token = ""
+        if auth_header.startswith("Bearer "):
+            token = auth_header.split(" ", 1)[1].strip()
+
+        if not expected_token or token != expected_token:
+            return _build_error_response(
+                message="Authentification requise.",
+                error_code="auth_invalid",
+                status=401,
+                error_message="Jeton Bearer invalide ou manquant.",
+            )
+
+        player = (
+            Player.query.options(joinedload(Player.stats))
+            .filter_by(id=player_id)
+            .first()
+        )
+
+        if player is None:
+            return _build_error_response(
+                message="Joueur introuvable.",
+                error_code="player_not_found",
+                status=404,
+            )
+
+        return _build_success_response(
+            _serialize_player(player),
+            message="Informations du joueur récupérées avec succès.",
+        )
 
     return app
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ def app():
         {
             "TESTING": True,
             "SQLALCHEMY_DATABASE_URI": "sqlite://",
+            "API_AUTH_TOKEN": "test-token",
         }
     )
 

--- a/tests/test_players_endpoint.py
+++ b/tests/test_players_endpoint.py
@@ -1,0 +1,65 @@
+"""Tests pour l'endpoint GET /players/{id}."""
+
+from src.extensions import db
+from src.models import Player, PlayerStats
+
+
+def _create_player():
+    player = Player(user_id="user-123", name="Test Player", level=5, xp=250)
+    stats = PlayerStats(health=150, attack=25, defense=18)
+    player.stats = stats
+    db.session.add(player)
+    db.session.commit()
+    return player
+
+
+def test_get_player_requires_auth(client):
+    response = client.get("/players/1")
+
+    assert response.status_code == 401
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "auth_invalid"
+
+
+def test_get_player_invalid_token(client):
+    response = client.get(
+        "/players/1",
+        headers={"Authorization": "Bearer invalid"},
+    )
+
+    assert response.status_code == 401
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "auth_invalid"
+
+
+def test_get_player_not_found(client):
+    response = client.get(
+        "/players/999",
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+    assert response.status_code == 404
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "player_not_found"
+
+
+def test_get_player_success(client, app):
+    with app.app_context():
+        player = _create_player()
+        player_id = player.id
+
+    response = client.get(
+        f"/players/{player_id}",
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["data"]["id"] == player_id
+    assert payload["data"]["user_id"] == "user-123"
+    assert payload["data"]["stats"]["health"] == 150
+    assert payload["message"] == "Informations du joueur récupérées avec succès."


### PR DESCRIPTION
## Summary
- add authentication helpers and GET /players/<id> endpoint returning player details and stats
- ensure tests configure API token for authenticated requests
- add endpoint tests covering auth, not found, and success scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1a692de9c8332aafe050798a22a81