### PR TITLE
feat: add player creation endpoint

### DIFF
--- a/tests/test_players_endpoint.py
+++ b/tests/test_players_endpoint.py
@@ -1,4 +1,4 @@
-"""Tests pour l'endpoint GET /players/{id}."""
+"""Tests pour les endpoints joueurs."""
 
 from src.extensions import db
 from src.models import Player, PlayerStats
@@ -63,3 +63,82 @@ def test_get_player_success(client, app):
     assert payload["data"]["user_id"] == "user-123"
     assert payload["data"]["stats"]["health"] == 150
     assert payload["message"] == "Informations du joueur récupérées avec succès."
+
+
+def test_create_player_requires_auth(client):
+    response = client.post(
+        "/players",
+        json={"name": "New Player"},
+    )
+
+    assert response.status_code == 401
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "auth_invalid"
+
+
+def test_create_player_missing_user_id(client):
+    response = client.post(
+        "/players",
+        json={"name": "New Player"},
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "user_id_missing"
+
+
+def test_create_player_missing_name(client):
+    response = client.post(
+        "/players",
+        json={},
+        headers={
+            "Authorization": "Bearer test-token",
+            "X-User-Id": "user-456",
+        },
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "invalid_payload"
+
+
+def test_create_player_conflict(client, app):
+    with app.app_context():
+        _create_player()
+
+    response = client.post(
+        "/players",
+        json={"name": "Duplicate"},
+        headers={
+            "Authorization": "Bearer test-token",
+            "X-User-Id": "user-123",
+        },
+    )
+
+    assert response.status_code == 409
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "player_already_exists"
+
+
+def test_create_player_success(client):
+    response = client.post(
+        "/players",
+        json={"name": "Umbra Hero"},
+        headers={
+            "Authorization": "Bearer test-token",
+            "X-User-Id": "user-789",
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["data"]["user_id"] == "user-789"
+    assert payload["data"]["name"] == "Umbra Hero"
+    assert payload["data"]["stats"]["health"] == 100
+    assert payload["message"] == "Joueur créé avec succès."


### PR DESCRIPTION
## Summary
- share bearer token handling utilities within the Flask app factory
- add POST /players endpoint to create authenticated player profiles with default stats
- expand player endpoint tests to cover creation flows and validation errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1a8b601248332846bf0ea3353a137